### PR TITLE
Implement Emergency Stop Pattern (Pausable) in smart contracts

### DIFF
--- a/hardhat/contracts/AgriYield.sol
+++ b/hardhat/contracts/AgriYield.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.8.20;
 import "./FarmShares.sol";
 import "./MockUSDT.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 
 
-contract AgriYield is ReentrancyGuard {
+contract AgriYield is ReentrancyGuard, Pausable {
     enum Status {
         Active,
         Funded,
@@ -48,6 +49,8 @@ contract AgriYield is ReentrancyGuard {
     event FarmClosed(uint256 indexed farmId);   
     event InvestorRefunded(uint256 indexed farmId, address indexed investor, uint256 amount);
     event ProceedsDeposited(uint256 indexed farmId, uint256 amount, uint256 roiPercent);
+    event Paused(address account);
+    event Unpaused(address account);
 
     modifier onlyAdmin() {
             require(msg.sender == admin, "AgriYield: only admin");
@@ -75,7 +78,7 @@ contract AgriYield is ReentrancyGuard {
         uint256 deadline,
         uint256 minROI,
         uint256 maxROI
-    ) external {
+    ) external whenNotPaused {
         require(fundingGoal > 0 && maxSupply > 0 && sharePrice > 0, "AgriYield: invalid args");
         require(fundingGoal == sharePrice * maxSupply, "AgriYield: inconsistent params");
         require(deadline > block.timestamp, "AgriYield: invalid deadline");
@@ -94,7 +97,7 @@ contract AgriYield is ReentrancyGuard {
         emit FarmVerified(farmId);
     }
 
-    function invest(uint256 farmId, uint256 amount) external nonReentrant {
+    function invest(uint256 farmId, uint256 amount) external nonReentrant whenNotPaused {
         Farm storage farm = farms[farmId];
         require(farm.verified, "Farm not verified");
         require(farm.status == Status.Active, "Farm not active");
@@ -136,7 +139,7 @@ contract AgriYield is ReentrancyGuard {
             emit FundDisbursed(farmId, amount);
     }
     
-    function depositProceeds(uint256 farmId, uint256 amount) external nonReentrant {
+    function depositProceeds(uint256 farmId, uint256 amount) external nonReentrant whenNotPaused {
         Farm storage f = farms[farmId];
         require(msg.sender == f.farmer, "Not farmer");
         require(f.status == Status.PaidOut, "Farm not paid out yet");
@@ -156,7 +159,7 @@ contract AgriYield is ReentrancyGuard {
     }
 
     /// @notice Investors claim proportional payout after settlement
-    function claimInvestorPayout(uint256 farmId) external nonReentrant {
+    function claimInvestorPayout(uint256 farmId) external nonReentrant whenNotPaused {
         Farm storage f = farms[farmId];
         require(f.status == Status.Settled, "AgriYield: Not settled");
 
@@ -229,6 +232,16 @@ contract AgriYield is ReentrancyGuard {
         Farm storage f = farms[farmId];
         minExpected = f.fundingGoal + ((f.fundingGoal * f.minROI) / 100);
         maxExpected = f.fundingGoal + ((f.fundingGoal * f.maxROI) / 100);
+    }
+
+    /// @notice Emergency pause function - only admin can call
+    function pause() external onlyAdmin {
+        _pause();
+    }
+
+    /// @notice Emergency unpause function - only admin can call
+    function unpause() external onlyAdmin {
+        _unpause();
     }
 
 }

--- a/hardhat/contracts/Marketplace.sol
+++ b/hardhat/contracts/Marketplace.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 
 interface IAgriYield {
     function getFarm(
@@ -29,7 +30,7 @@ interface IAgriYield {
         );
 }
 
-contract Marketplace is ReentrancyGuard {
+contract Marketplace is ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
 
     IERC20 public AGT; // same AGT token used in AgriYield
@@ -111,6 +112,8 @@ contract Marketplace is ReentrancyGuard {
     event DisputeOpened(uint256 indexed orderId, string reasonCID);
     event DisputeResolved(uint256 indexed orderId, bool sellerFavor);
     event AdminChanged(address indexed newAdmin);
+    event Paused(address account);
+    event Unpaused(address account);
 
     constructor(address _stableToken, address _agriYield, address _admin) {
         require(_stableToken != address(0), "Marketplace: zero token");
@@ -140,7 +143,7 @@ contract Marketplace is ReentrancyGuard {
         uint256 price,
         uint256 quantity,
         string calldata metadataCID
-    ) external returns (uint256) {
+    ) external whenNotPaused returns (uint256) {
         require(price > 0, "Marketplace: price>0");
         require(quantity > 0, "Marketplace: qty>0");
 
@@ -200,7 +203,7 @@ contract Marketplace is ReentrancyGuard {
     function purchase(
         uint256 listingId,
         uint256 quantity
-    ) external nonReentrant returns (uint256) {
+    ) external nonReentrant whenNotPaused returns (uint256) {
         Listing storage l = listings[listingId];
         require(l.isActive, "Marketplace: inactive");
         require(
@@ -346,5 +349,15 @@ contract Marketplace is ReentrancyGuard {
     }
     function getUserOrders(address user) external view returns (uint256[] memory) {
         return userOrders[user];
+    }
+
+    /// @notice Emergency pause function - only admin can call
+    function pause() external onlyAdmin {
+        _pause();
+    }
+
+    /// @notice Emergency unpause function - only admin can call
+    function unpause() external onlyAdmin {
+        _unpause();
     }
 }


### PR DESCRIPTION
This addresses Issue #19 (Emergency Stop Pattern #28):

AgriYield.sol:
- Import OpenZeppelin Pausable contract
- Make contract inherit from Pausable in addition to ReentrancyGuard
- Add Paused and Unpaused events
- Add whenNotPaused modifiers to critical functions:
  - createFarm()
  - invest()
  - depositProceeds()
  - claimInvestorPayout()
- Add pause() and unpause() functions callable only by admin

Marketplace.sol:
- Import OpenZeppelin Pausable contract
- Make contract inherit from Pausable in addition to ReentrancyGuard
- Add Paused and Unpaused events
- Add whenNotPaused modifiers to critical functions:
  - listItem()
  - purchase()
- Add pause() and unpause() functions callable only by admin

This allows emergency stopping of critical operations to prevent malicious or buggy behavior.